### PR TITLE
chore(customization_cart): customizations_replicated_products_in_cart

### DIFF
--- a/src/constructor.js
+++ b/src/constructor.js
@@ -10,7 +10,6 @@ import removeItem from './methods/remove-item'
 import save from './methods/save'
 import clear from './methods/clear'
 import reset from './methods/reset'
-import * as cloneDeep from 'lodash.clonedeep'
 
 const defaultStorage = typeof window === 'object' && window.localStorage
 
@@ -82,19 +81,6 @@ const EcomCart = function (storeId, storageKey = 'ecomShoppingCart', localStorag
     subtotal: 0
   }
 
-  /**
-   * Shopping cart data following
-   * @memberof EcomCart
-   * @type {object}
-   * @property {string} _id - Cart object ID
-   * @property {array<object>} items - List of cart items
-   * @property {number} subtotal - Cart subtotal value
-  */
-  ecomCart.cart = {
-    items: [],
-    subtotal: 0
-  }
-
   const emitter = new EventEmitter()
   ;['on', 'off', 'once'].forEach(method => {
     ecomCart[method] = (ev, fn) => {
@@ -123,10 +109,7 @@ const EcomCart = function (storeId, storageKey = 'ecomShoppingCart', localStorag
   }
 
   this.addProduct = (product, variationId, quantity, canSave) => {
-    if(ecomCart.cart.items) ecomCart.data = ecomCart.cart
-    const productAdded = methodsMiddleware(addPoduct, [product, variationId, quantity, canSave])
-    ecomCart.cart = cloneDeep(ecomCart.data)
-    return productAdded
+    return methodsMiddleware(addPoduct, [product, variationId, quantity, canSave])
   }
 
   this.fixItem = (item, canSave) => {
@@ -168,7 +151,6 @@ const EcomCart = function (storeId, storageKey = 'ecomShoppingCart', localStorag
       }
       if (data && Array.isArray(data.items)) {
         ecomCart.data = data
-        ecomCart.cart = data
       }
     }
   }

--- a/src/constructor.js
+++ b/src/constructor.js
@@ -10,6 +10,7 @@ import removeItem from './methods/remove-item'
 import save from './methods/save'
 import clear from './methods/clear'
 import reset from './methods/reset'
+import * as cloneDeep from 'lodash.clonedeep'
 
 const defaultStorage = typeof window === 'object' && window.localStorage
 

--- a/src/constructor.js
+++ b/src/constructor.js
@@ -81,6 +81,19 @@ const EcomCart = function (storeId, storageKey = 'ecomShoppingCart', localStorag
     subtotal: 0
   }
 
+  /**
+   * Shopping cart data following
+   * @memberof EcomCart
+   * @type {object}
+   * @property {string} _id - Cart object ID
+   * @property {array<object>} items - List of cart items
+   * @property {number} subtotal - Cart subtotal value
+  */
+  ecomCart.cart = {
+    items: [],
+    subtotal: 0
+  }
+
   const emitter = new EventEmitter()
   ;['on', 'off', 'once'].forEach(method => {
     ecomCart[method] = (ev, fn) => {
@@ -109,7 +122,10 @@ const EcomCart = function (storeId, storageKey = 'ecomShoppingCart', localStorag
   }
 
   this.addProduct = (product, variationId, quantity, canSave) => {
-    return methodsMiddleware(addPoduct, [product, variationId, quantity, canSave])
+    if(ecomCart.cart.items) ecomCart.data = ecomCart.cart
+    const productAdded = methodsMiddleware(addPoduct, [product, variationId, quantity, canSave])
+    ecomCart.cart = cloneDeep(ecomCart.data)
+    return productAdded
   }
 
   this.fixItem = (item, canSave) => {
@@ -151,6 +167,7 @@ const EcomCart = function (storeId, storageKey = 'ecomShoppingCart', localStorag
       }
       if (data && Array.isArray(data.items)) {
         ecomCart.data = data
+        ecomCart.cart = data
       }
     }
   }

--- a/src/methods/add-item.js
+++ b/src/methods/add-item.js
@@ -72,7 +72,6 @@ export default ({ data, save }, emitter, [newItem, canSave = true]) => {
     if (newItem.customizations) {
       newItem.customizations.forEach((customization, i) => {
         itemCopy.customizations[i] = Object.assign({}, customization)
-        console.log(itemCopy.customizations[i])
       })
     }
     data.items.push(itemCopy)

--- a/src/methods/add-item.js
+++ b/src/methods/add-item.js
@@ -37,6 +37,9 @@ export default ({ data, save }, emitter, [newItem, canSave = true]) => {
   ) {
     return null
   }
+  try {
+    data = { ...data, items: JSON.parse(localStorage.getItem('ecomShoppingCart')).items}
+  } catch (e) { }
 
   let fixedItem
   if (!newItem.kit_product) {

--- a/src/methods/add-item.js
+++ b/src/methods/add-item.js
@@ -69,6 +69,12 @@ export default ({ data, save }, emitter, [newItem, canSave = true]) => {
     ) {
       itemCopy._id = randomObjectId()
     }
+    if (newItem.customizations) {
+      newItem.customizations.forEach((customization, i) => {
+        itemCopy.customizations[i] = Object.assign({}, customization)
+        console.log(itemCopy.customizations[i])
+      })
+    }
     data.items.push(itemCopy)
     fixedItem = fixItemQuantity(itemCopy)
     fixItemFinalPrice(fixedItem)

--- a/src/methods/add-item.js
+++ b/src/methods/add-item.js
@@ -37,9 +37,6 @@ export default ({ data, save }, emitter, [newItem, canSave = true]) => {
   ) {
     return null
   }
-  try {
-    data = { ...data, items: JSON.parse(localStorage.getItem('ecomShoppingCart')).items}
-  } catch (e) { }
 
   let fixedItem
   if (!newItem.kit_product) {


### PR DESCRIPTION
Issue-test:
Adicionar um produto com customização no cart, no momento em que voltamos ao produto e adicionamos um segundo produto com outra customização, o primeiro sofre alteração desses campos, ficando com as mesmas customizações do último adicionado ao cart.

Solution:
A prop customizations é adicionada aos items (product) do cart separadamente das demais props, assim, é alterada toda vez que o(s) campo(s) de customização(es) também é alterado. A PR faz com que os produtos que já estavam no carrinho sejam readicionados com suas props "antigas", sem edição, no momento em que um novo produto é adicionado.